### PR TITLE
feat(android): integrated new Credential Manager based sign-in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ ios/ti.googlesignin.xcodeproj/xcuserdata
 /ios/dist
 ios/ti.googlesignin-iphone-*.zip
 android/dist
+/android/.gradle

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,4 +1,9 @@
 
-dependencies {
-	implementation "com.google.android.gms:play-services-auth:20.7.0"
+dependencies {    
+	implementation "androidx.credentials:credentials:1.3.0"
+
+    // For credentials support from play services on Android <= 13.
+    implementation "androidx.credentials:credentials-play-services-auth:1.3.0"
+
+    implementation "com.google.android.libraries.identity.googleid:googleid:1.1.1"
 }

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 7.3.0
+version: 8.0.0
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: ti.googlesignin
@@ -15,4 +15,4 @@ name: googlesignin
 moduleid: ti.googlesignin
 guid: d548b85b-bfcb-43c5-a13d-a63d148ba8a0
 platform: android
-minsdk: 9.0.0
+minsdk: 12.6.1

--- a/android/manifest
+++ b/android/manifest
@@ -15,4 +15,4 @@ name: googlesignin
 moduleid: ti.googlesignin
 guid: d548b85b-bfcb-43c5-a13d-a63d148ba8a0
 platform: android
-minsdk: 12.6.1
+minsdk: 12.7.0.GA

--- a/android/src/ti/googlesignin/TiCredentialManager.kt
+++ b/android/src/ti/googlesignin/TiCredentialManager.kt
@@ -1,0 +1,126 @@
+package ti.googlesignin
+
+import android.content.Context
+import androidx.credentials.ClearCredentialStateRequest
+import androidx.credentials.CredentialManager
+import androidx.credentials.CredentialManagerCallback
+import androidx.credentials.CustomCredential
+import androidx.credentials.GetCredentialRequest
+import androidx.credentials.GetCredentialResponse
+import androidx.credentials.exceptions.ClearCredentialException
+import androidx.credentials.exceptions.GetCredentialCancellationException
+import androidx.credentials.exceptions.GetCredentialException
+import androidx.credentials.exceptions.GetCredentialInterruptedException
+import androidx.credentials.exceptions.NoCredentialException
+import com.google.android.libraries.identity.googleid.GetGoogleIdOption
+import com.google.android.libraries.identity.googleid.GetSignInWithGoogleOption
+import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
+import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential.Companion.TYPE_GOOGLE_ID_TOKEN_CREDENTIAL
+import com.google.android.libraries.identity.googleid.GoogleIdTokenParsingException
+import org.appcelerator.kroll.KrollDict
+import org.appcelerator.titanium.TiApplication
+import ti.googlesignin.GooglesigninModule.Companion.ERROR_TYPE_CANCELLED
+import ti.googlesignin.GooglesigninModule.Companion.ERROR_TYPE_INTERRUPTED
+import ti.googlesignin.GooglesigninModule.Companion.ERROR_TYPE_NO_CREDENTIAL
+import ti.googlesignin.GooglesigninModule.Companion.ERROR_TYPE_TOKEN_PARSING
+import ti.googlesignin.GooglesigninModule.Companion.LOGIN_TYPE_DIALOG
+import ti.googlesignin.GooglesigninModule.Companion.LOGIN_TYPE_SHEET
+
+
+object TiCredentialManager {
+    lateinit var apiKey: String
+    private lateinit var credentialManager: CredentialManager
+
+    private fun getContext(): Context {
+        return TiApplication.getAppCurrentActivity().baseContext
+    }
+
+    private fun createCredentialManager() {
+        if (::credentialManager.isInitialized.not()) {
+            credentialManager = CredentialManager.create(getContext())
+        }
+    }
+
+    fun googleSignIn(module: GooglesigninModule, params: KrollDict?) {
+        createCredentialManager()
+
+        val loginType = params?.optString("loginType", LOGIN_TYPE_SHEET) ?: LOGIN_TYPE_SHEET
+
+        // If specified, use dialog based sign-in as in previous module. Otherwise use latest bottom-sheet based sign-in.
+        val credentialOption = if (loginType == LOGIN_TYPE_DIALOG) {
+            GetSignInWithGoogleOption.Builder(apiKey).build()
+        } else {
+            GetGoogleIdOption.Builder()
+                .setFilterByAuthorizedAccounts(params?.optBoolean("filterByAuthorizedAccounts", false) ?: false)
+                .setAutoSelectEnabled(params?.optBoolean("autoSelectEnabled", false) ?: false)
+                .setRequestVerifiedPhoneNumber(params?.optBoolean("requestVerifiedPhoneNumber", false) ?: false)
+                .setServerClientId(apiKey)
+                .setNonce(params?.optString("nonce", null))
+                .build()
+        }
+
+        val request = GetCredentialRequest.Builder()
+            .addCredentialOption(credentialOption)
+            .build()
+
+        credentialManager.getCredentialAsync(
+            context = getContext(),
+            request = request,
+            cancellationSignal = module.cancellationSignal,
+            executor = Runnable::run,
+            callback = object : CredentialManagerCallback<GetCredentialResponse, GetCredentialException> {
+                override fun onError(e: GetCredentialException) {
+                    onCredentialError(module, e)
+                }
+
+                override fun onResult(result: GetCredentialResponse) {
+                    onCredentialResult(module, result)
+                }
+            }
+        )
+    }
+
+    private fun onCredentialError(module: GooglesigninModule, e: Exception) {
+        when (e) {
+            // Likely try again with `filterByAuthorizedAccounts: false` if it were `true` previously.
+            is NoCredentialException -> module.fireLoginEvent(errorType = ERROR_TYPE_NO_CREDENTIAL, error = e)
+            is GetCredentialInterruptedException -> module.fireLoginEvent(errorType = ERROR_TYPE_INTERRUPTED, error = e)
+            is GetCredentialCancellationException -> module.fireLoginEvent(cancelled = true, errorType = ERROR_TYPE_CANCELLED, error = e)
+            else -> module.fireLoginEvent()
+        }
+    }
+
+    private fun onCredentialResult(module: GooglesigninModule, result: GetCredentialResponse) {
+        val googleCredentials = result.credential
+        if (googleCredentials is CustomCredential && googleCredentials.type == TYPE_GOOGLE_ID_TOKEN_CREDENTIAL) {
+            try {
+                val googleIdTokenCredential = GoogleIdTokenCredential.createFrom(googleCredentials.data)
+                module.fireLoginEvent(credential = googleIdTokenCredential)
+
+            } catch (e: GoogleIdTokenParsingException) {
+                module.fireLoginEvent(errorType = ERROR_TYPE_TOKEN_PARSING, error = e)
+            }
+        } else {
+            module.fireLoginEvent()
+        }
+    }
+
+    fun signOut(module: GooglesigninModule) {
+        createCredentialManager()
+
+        credentialManager.clearCredentialStateAsync(
+            request = ClearCredentialStateRequest(),
+            cancellationSignal = null,
+            executor = Runnable::run,
+            callback = object : CredentialManagerCallback<Void?, ClearCredentialException> {
+                override fun onError(e: ClearCredentialException) {
+                    module.fireLogoutEvent(error = e.errorMessage?.toString() ?: "")
+                }
+
+                override fun onResult(result: Void?) {
+                    module.fireLogoutEvent(success = true)
+                }
+            }
+        )
+    }
+}

--- a/android/src/ti/googlesignin/TiCredentialManager.kt
+++ b/android/src/ti/googlesignin/TiCredentialManager.kt
@@ -32,7 +32,7 @@ object TiCredentialManager {
     private lateinit var credentialManager: CredentialManager
 
     private fun getContext(): Context {
-        return TiApplication.getAppCurrentActivity().baseContext
+        return TiApplication.getAppRootOrCurrentActivity()
     }
 
     private fun createCredentialManager() {


### PR DESCRIPTION
**NOTE:** This module requires minimum `compileSdkVersion: 34` which is not publicly available until `SDK 12.6.1.GA`.
I tested the module using latest master branch, so `manifest` will be updated once we release public release from master.

- Migrate [Google Sign-In for Android](https://developers.google.com/identity/sign-in/android/start-integrating) to [Android Credential Manager](https://developer.android.com/identity/sign-in/credential-manager-siwg).
- Google Sign-In for Android is deprecated and will be removed from the [Google Play Services Auth SDK](https://maven.google.com/web/index.html?q=play-services-auth#com.google.android.gms:play-services-auth). (com.google.android.gms:play-services-auth) in 2025.

**New properties in `signIn` method:**
- `loginType`
   - `LOGIN_TYPE_SHEET` - default, new UI in Credential Manager
   - `LOGIN_TYPE_DIALOG` - previous dialog based UI.
- `filterByAuthorizedAccounts` [details](https://developers.google.com/identity/android-credential-manager/android/reference/kotlin/com/google/android/libraries/identity/googleid/GetGoogleIdOption#filterByAuthorizedAccounts())
- `autoSelectEnabled` [details](https://developer.android.com/identity/sign-in/credential-manager-siwg#enable-sign-in)
- `requestVerifiedPhoneNumber` [details](https://developers.google.com/identity/android-credential-manager/android/reference/kotlin/com/google/android/libraries/identity/googleid/GetGoogleIdOption#requestVerifiedPhoneNumber())
- `nonce` [details](https://developer.android.com/identity/sign-in/credential-manager-siwg#set-nonce)

**New methods**
- `cancel()` allows to cancel the currently shown sign in UI.

<hr>

**Removed below methods/props from module due to Credential Manager changes:**
- `disconnect`
- `signInSilently`
- `hasAuthInKeychain`
- `currentUser`

**Google removed some properties from `login` event as part of their security reasons:**
- `scopes` - part of new different Authorization API flow under Credential Manager
- `accountType`
- `accountString`
- `serverAuthCode`