### PR TITLE
chore(android): use current activity context for presenting the dialog

### DIFF
--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 8.0.0
+version: 9.0.0
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: ti.googlesignin

--- a/android/src/ti/googlesignin/GooglesigninModule.kt
+++ b/android/src/ti/googlesignin/GooglesigninModule.kt
@@ -30,6 +30,7 @@ class GooglesigninModule : KrollModule() {
         @Kroll.constant val LOGIN_TYPE_SHEET = "LOGIN_TYPE_SHEET"
 
         @Kroll.constant val ERROR_TYPE_UNKNOWN = "ERROR_TYPE_UNKNOWN"
+        @Kroll.constant val ERROR_TYPE_CONTEXT_MISSING = "ERROR_TYPE_CONTEXT_MISSING"
         @Kroll.constant val ERROR_TYPE_NO_CREDENTIAL = "ERROR_TYPE_NO_CREDENTIAL"
         @Kroll.constant val ERROR_TYPE_TOKEN_PARSING = "ERROR_TYPE_TOKEN_PARSING"
         @Kroll.constant val ERROR_TYPE_INTERRUPTED = "ERROR_TYPE_INTERRUPTED"


### PR DESCRIPTION
1. Compiled for 16KB alignment.
2. Used `current activity context` when presenting the sign-in dialog, and `applicationContext` for sign-out as it does not involve any UI internally.
3. Bumped version to `9.0.0`.