### PR TITLE
fix(android): use main looper thread for Credential Manager callback

### DIFF
--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 9.0.0
+version: 9.0.1
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: ti.googlesignin

--- a/android/src/ti/googlesignin/GooglesigninModule.kt
+++ b/android/src/ti/googlesignin/GooglesigninModule.kt
@@ -35,6 +35,8 @@ class GooglesigninModule : KrollModule() {
         @Kroll.constant val ERROR_TYPE_TOKEN_PARSING = "ERROR_TYPE_TOKEN_PARSING"
         @Kroll.constant val ERROR_TYPE_INTERRUPTED = "ERROR_TYPE_INTERRUPTED"
         @Kroll.constant val ERROR_TYPE_CANCELLED = "ERROR_TYPE_CANCELLED"
+        @Kroll.constant val ERROR_TYPE_CONFIGURATION = "ERROR_TYPE_CONFIGURATION"
+        @Kroll.constant val ERROR_TYPE_UNSUPPORTED = "ERROR_TYPE_UNSUPPORTED"
     }
 
     @method


### PR DESCRIPTION
- Fixes a possible issue where the Credential Manager's `callback` can be invoked on a different thread than the app's main-thread.
- Adds remaining error types to be handled gracefully on the app side.

[ti.googlesignin-android-9.0.1.zip](https://github.com/user-attachments/files/24102246/ti.googlesignin-android-9.0.1.zip)
